### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -3,6 +3,7 @@ glktermw (1.0.4+git20200122-3) UNRELEASED; urgency=medium
   * Trim trailing whitespace.
   * Upgrade to newer source format 3.0 (quilt).
   * Set debhelper-compat version in Build-Depends.
+  * Bump debhelper from old 11 to 13.
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 22 Jun 2021 21:28:13 -0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -4,6 +4,8 @@ glktermw (1.0.4+git20200122-3) UNRELEASED; urgency=medium
   * Upgrade to newer source format 3.0 (quilt).
   * Set debhelper-compat version in Build-Depends.
   * Bump debhelper from old 11 to 13.
+  * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository,
+    Repository-Browse.
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 22 Jun 2021 21:28:13 -0000
 

--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: glktermw
 Priority: optional
 Maintainer: John Goerzen <jgoerzen@complete.org>
-Build-Depends: debhelper-compat (= 11), libncurses-dev
+Build-Depends: debhelper-compat (= 13), libncurses-dev
 Standards-Version: 4.1.3
 Section: libs
 Homepage: https://www.eblong.com/zarf/glk/index.html

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,5 @@
+---
+Bug-Database: https://github.com/erkyrath/glkterm/issues
+Bug-Submit: https://github.com/erkyrath/glkterm/issues/new
+Repository: https://github.com/erkyrath/glkterm.git
+Repository-Browse: https://github.com/erkyrath/glkterm


### PR DESCRIPTION
Fix some issues reported by lintian

* Bump debhelper from old 11 to 13. ([package-uses-old-debhelper-compat-version](https://lintian.debian.org/tags/package-uses-old-debhelper-compat-version))

* Set upstream metadata fields: Bug-Database, Bug-Submit, Repository, Repository-Browse. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing), [upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking), [upstream-metadata-missing-repository](https://lintian.debian.org/tags/upstream-metadata-missing-repository))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/lintian-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/glktermw/195f65db-b40c-45de-bf30-1b2f860d461a.



These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/195f65db-b40c-45de-bf30-1b2f860d461a/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/195f65db-b40c-45de-bf30-1b2f860d461a/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/195f65db-b40c-45de-bf30-1b2f860d461a/diffoscope)).
